### PR TITLE
Release v_5 (1_0_2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # SevenSec
 
+## v1.0.2 + 5
+## issues
+Crash solved when user open detail screen for candy crush app
+
+## improvements
+Remove the snackBar from splash screen
+Show 'No network!' text above "Retry" button.
+For login, once the network is available "login" will start. User don't need to click on "retry" button
+Stop Zooming Barchart in both X, Y axis
+
 ## v1.0.2 + 4
 ## issues
 Crash solved for anonymous login in home screen - integrated the flow to SplashScreen 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# SevenSec
+
+## v1.0.2 + 4
+## issues
+Crash solved for anonymous login in home screen - integrated the flow to SplashScreen 
+
+## improvements
+Added search
+Added internet check in Splash. 
+Integrated Room.db removing SharedPreferences.
+
+## features
+Integrated ChartView for App visits in App details screen.
+
+## v1.0.1 && v1.0.0
+## features - Initial Release.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "com.sevensec"
         minSdk 23
         targetSdk 33
-        versionCode 4
+        versionCode 5
         versionName "1.0.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/sevensec/activities/AppDetailsActivity.java
+++ b/app/src/main/java/com/sevensec/activities/AppDetailsActivity.java
@@ -248,6 +248,9 @@ public class AppDetailsActivity extends AppCompatActivity {
         //Animation
         binding.barChartView.animateY(1000);
 
+        //Stop zooming
+        binding.barChartView.setScaleEnabled(false);
+
         binding.barChartView.setData(data);
         binding.barChartView.invalidate();
     }

--- a/app/src/main/java/com/sevensec/activities/SplashActivity.java
+++ b/app/src/main/java/com/sevensec/activities/SplashActivity.java
@@ -8,16 +8,17 @@ import static com.sevensec.utils.Constants.SPLASH_DELAY;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkRequest;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
 import android.view.View;
 import android.view.WindowManager;
 
-import androidx.core.content.ContextCompat;
 import androidx.databinding.DataBindingUtil;
 
-import com.google.android.material.snackbar.Snackbar;
 import com.sevensec.BuildConfig;
 import com.sevensec.R;
 import com.sevensec.databinding.ActivitySplashBinding;
@@ -36,6 +37,30 @@ public class SplashActivity extends FireBaseAuthOperation implements AuthFailure
 
     ActivitySplashBinding binding;
 
+    String DEVICE_ID;
+
+    ConnectivityManager connMgr;
+
+    // Define a NetworkCallback object
+    ConnectivityManager.NetworkCallback networkCallback = new ConnectivityManager.NetworkCallback() {
+        @Override
+        public void onAvailable(Network network) {
+            // The network is available
+            // Do something here, such as update your UI
+            Dlog.d("Internet: onAvailable");
+            runOnUiThread(() -> checkForLogin(getApplicationContext(), DEVICE_ID, true));
+        }
+
+        @Override
+        public void onLost(Network network) {
+            // The network is lost
+            // Do something here, such as update your UI
+            Dlog.d("Internet: onLost");
+            runOnUiThread(() -> checkForLogin(getApplicationContext(), DEVICE_ID, false));
+        }
+    };
+
+    @SuppressLint("HardwareIds")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,7 +73,7 @@ public class SplashActivity extends FireBaseAuthOperation implements AuthFailure
         binding.appVersion.setText(String.format("v %s", BuildConfig.VERSION_NAME));
 
         //Store DEVICE_ID in Preference
-        @SuppressLint("HardwareIds") String DEVICE_ID = Settings.Secure.getString(getApplicationContext().getContentResolver(), Settings.Secure.ANDROID_ID);
+        DEVICE_ID = Settings.Secure.getString(getApplicationContext().getContentResolver(), Settings.Secure.ANDROID_ID);
         Dlog.d("OnBoardingActivity onCreate DEVICE_ID: " + DEVICE_ID);
         SharedPref.writeString(PREF_DEVICE_ID, DEVICE_ID);
 
@@ -56,6 +81,7 @@ public class SplashActivity extends FireBaseAuthOperation implements AuthFailure
 
             binding.progressBar.setVisibility(View.GONE);
             binding.llNoInternet.setVisibility(View.GONE);
+            binding.tvNoInternet.setVisibility(View.GONE);
 
             new Handler().postDelayed(() -> {
                 if (SharedPref.readBoolean(PREF_IS_APP_LAUNCH_FIRST_TIME, true)) {
@@ -67,24 +93,36 @@ public class SplashActivity extends FireBaseAuthOperation implements AuthFailure
             }, SPLASH_DELAY);
 
         } else {
-            checkForLogin(getApplicationContext(), DEVICE_ID);
+
+            if(!Utils.isInternetAvailable(this)){
+                binding.progressBar.setVisibility(View.GONE);
+                binding.llNoInternet.setVisibility(View.VISIBLE);
+                binding.tvNoInternet.setVisibility(View.VISIBLE);
+            }
+
+            // Get an instance of the ConnectivityManager
+            connMgr = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+
+            // Register the network callback
+            NetworkRequest.Builder builder = new NetworkRequest.Builder();
+            connMgr.registerNetworkCallback(builder.build(), networkCallback);
         }
 
-        binding.tvReTry.setOnClickListener(v -> checkForLogin(getApplicationContext(), DEVICE_ID));
+        binding.tvReTry.setOnClickListener(v -> checkForLogin(this, DEVICE_ID, Utils.isInternetAvailable(this)));
     }
 
-    private void checkForLogin(Context context, String device_id) {
-        if (Utils.isInternetAvailable(this)) {
+    private void checkForLogin(Context context, String device_id, boolean isInternetAvailable) {
+        if (isInternetAvailable) {
             binding.progressBar.setVisibility(View.VISIBLE);
             binding.llNoInternet.setVisibility(View.GONE);
+            binding.tvNoInternet.setVisibility(View.GONE);
 
             loginAnonymously(context, device_id, this);
 
         } else {
             binding.progressBar.setVisibility(View.GONE);
             binding.llNoInternet.setVisibility(View.VISIBLE);
-
-            showSnackBar(getApplicationContext(), binding.rlMain);
+            binding.tvNoInternet.setVisibility(View.VISIBLE);
         }
     }
 
@@ -93,9 +131,11 @@ public class SplashActivity extends FireBaseAuthOperation implements AuthFailure
         SharedPref.writeBoolean(PREF_IS_LOGIN, false);
     }
 
-    public static void showSnackBar(Context mcontext, View parentLayout) {
-        Snackbar.make(parentLayout, mcontext.getResources().getString(R.string.no_internet_connection), Snackbar.LENGTH_LONG)
-                .setBackgroundTint(ContextCompat.getColor(mcontext, android.R.color.holo_red_light))
-                .show();
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (connMgr != null) {
+            connMgr.unregisterNetworkCallback(networkCallback);
+        }
     }
 }

--- a/app/src/main/java/com/sevensec/model/AppInfoModel.java
+++ b/app/src/main/java/com/sevensec/model/AppInfoModel.java
@@ -5,6 +5,8 @@ import android.graphics.Bitmap;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.sevensec.utils.Dlog;
+
 public class AppInfoModel implements Parcelable {
     private ApplicationInfo appInfo;
     private Bitmap appIconBitmap;
@@ -13,7 +15,7 @@ public class AppInfoModel implements Parcelable {
     private String category;
     private boolean isFavorite;
 
-    public AppInfoModel(){
+    public AppInfoModel() {
     }
 
     public ApplicationInfo getAppInfo() {
@@ -92,7 +94,13 @@ public class AppInfoModel implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeParcelable(appInfo, flags);
-        dest.writeParcelable(appIconBitmap, flags);
+
+        Dlog.e("appIconBitmap Width: " + appIconBitmap.getWidth() +" ,Height: "+ appIconBitmap.getHeight());
+        // Scale down the bitmap
+        Bitmap scaledBitmap = Bitmap.createScaledBitmap(appIconBitmap, 300, 300, true);
+        Dlog.i("scaledBitmap Width: " + scaledBitmap.getWidth() +" ,Height: "+ scaledBitmap.getHeight());
+
+        dest.writeParcelable(scaledBitmap, flags);
         dest.writeString(appName);
         dest.writeString(packageName);
         dest.writeString(category);

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -36,7 +36,22 @@
                 android:id="@+id/progressBar"
                 android:layout_width="@dimen/space_30"
                 android:layout_height="@dimen/space_30"
-                android:layout_marginBottom="@dimen/space_30" />
+                android:layout_marginBottom="@dimen/space_30"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/tvNoInternet"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/space_20"
+                android:paddingTop="@dimen/space_8"
+                android:paddingEnd="@dimen/space_20"
+                android:paddingBottom="@dimen/space_8"
+                android:text="@string/no_network"
+                android:textColor="@color/primary200"
+                android:textSize="18sp"
+                tools:targetApi="p"
+                android:visibility="gone"/>
 
             <LinearLayout
                 android:id="@+id/llNoInternet"
@@ -45,7 +60,7 @@
                 android:layout_marginBottom="@dimen/space_30"
                 android:gravity="center"
                 android:orientation="horizontal"
-                android:visibility="visible">
+                android:visibility="gone">
 
                 <RelativeLayout
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="no_internet_connection">No Internet Connection</string>
     <string name="please_try_again">Please try again</string>
     <string name="retry">Retry</string>
+    <string name="no_network">No network!</string>
 
     <string-array name="arrOnBoardingTitleList">
         <item>Start Delaying \nDistracting Apps</item>


### PR DESCRIPTION
issues:
- Crash solved when user open detail screen for candy crush app

improvements:
- Remove the snackBar from splash screen
- Show 'No network!' text above "Retry" button.
- For login, once the network is available "login" will start. User don't need to click on "retry" button
- Stop Zooming Barchart in both X, Y axis